### PR TITLE
Change to github superlinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,5 +1,5 @@
 ---
-name: Lint Code Base
+name: Linting
 
 on:
   pull_request:


### PR DESCRIPTION
# Overview

Change individual linters all to github [super-linter](https://github.com/github/super-linter).

Closes #18 