### PR TITLE
fix: QGC can now arm/disarm plane and upload flight plans to SITL

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -3,8 +3,9 @@ version: "3"
 services:
   hub:
     image: tritonuas/hub
-    ports:
-      - 5000:5000
+    network_mode: "host"
+    # ports:
+    #   - 5000:5000
     environment:
       - DEBUG_MODE=true
       - INTEROP_IP=host.docker.internal
@@ -13,17 +14,17 @@ services:
       - INTEROP_PASS=testpass
       - RTPP_IP=host.docker.internal
       - RTPP_PORT=5010
-      - MAV_DEVICE=tcp:sitl:5760
+      - MAV_DEVICE=tcp:localhost:5760
       # - MAV_DEVICE=udp:mavproxy:14555
-      - MAV_OUTPUT1=udp:192.168.1.2:14551
-      - MAV_OUTPUT2=udp:192.168.1.7:14551
-      - MAV_OUTPUT3=udp:host.docker.internal:14551
-      - MAV_OUTPUT4=udp:172.17.0.1:14550
-      - MAV_OUTPUT5=""
+      # - MAV_OUTPUT1=udp:192.168.1.2:14551
+      # - MAV_OUTPUT2=udp:192.168.1.7:14551
+      # - MAV_OUTPUT3=udp:host.docker.internal:14551
+      # - MAV_OUTPUT4=udp:172.17.0.1:14550
+      - MAV_OUTPUT5=udp:localhost:14551
       - INFLUXDB_BUCKET=mavlink
       - INFLUXDB_ORG=TritonUAS
       - INFLUXDB_TOKEN=influxdbToken
-      - INFLUXDB_URI=http://influxdb:8086
+      - INFLUXDB_URI=http://localhost:8086
       - HUB_PATH=/go/src/github.com/tritonuas/hub
     volumes:
       - missions:/go/src/github.com/tritonuas/hub/missions
@@ -32,14 +33,16 @@ services:
       
   influxdb:
     image: influxdb:2.0-alpine
-    ports:
-      - 8086:8086
+    network_mode: "host"
+    # ports:
+    #   - 8086:8086
     volumes:
       - influxdb_data:/var/lib/influxdb
   grafana:
     image: grafana/grafana:7.5.5
-    ports:
-      - 3000:3000
+    network_mode: "host"
+    # ports:
+    #   - 3000:3000
     depends_on:
       - hub 
     environment: 
@@ -61,6 +64,7 @@ services:
     depends_on:
       - influxdb
     image: influxdb:2.0-alpine
+    network_mode: "host"
     entrypoint: > 
       influx setup 
       --bucket mavlink 
@@ -68,13 +72,14 @@ services:
       --token influxdbToken 
       --username tritons 
       --password tritonuas 
-      --host http://influxdb:8086 
+      --host http://localhost:8086 
       --force
     restart: on-failure:20
   sitl:
     image: tritonuas/plane.rascal
-    ports:
-      - 5760:5760
+    network_mode: "host"
+    # ports:
+    #   - 5760:5760
     environment:
       - "SITL_HOME=38.145844,-76.42638,8,0"
       - SITL_SPEEDUP=1
@@ -87,31 +92,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - 9999:8080
-  # mavproxy:
-  #   image: tritonuas/mavproxy
-  #   # depends_on: 
-  #   #   - sitl
-  #   ports:
-  #     - "5761:5762"
-  #     - "14551:14551"
-  #   environment:
-  #     - "MASTER=--master=tcp:sitl:5760"
-  #     # - "OUT1=--out=udp:172.17.0.1:14550"
-  #     # Forwards messages to MissionPlanner/QGC
-  #     - "OUT1=--out=172.17.0.1:14550"
-  #     # Forwards messages to hub
-  #     - "OUT2=--out=udpin:mavproxy:14551"
-  #     - "OUT2=--out=udp:mavproxy:14555"
-  #     - "OUT3=--out=udp:192.168.1.2:14551"
-  #     - "OUT4=--out=udp:192.168.1.7:14551"
-  #     # - "OUT3=--out=udp:mavproxy:14556"
-  #     # - "OUT4=--out=tcpin:mavproxy:5761"
-  #     # - "OUT5=--out=udp:mavproxy:5762"
-  #     # - OUT6=
-  #     # - OUT7=
-  #   restart: always
-  #   # logging:
-  #   #   driver: none
 
 volumes:
   grafana_data:


### PR DESCRIPTION
Previously, when using QGroundControl with the mavlink router of hub we were not able to arm/disarm the plane and upload flight data to the SITL. QGC was trying to send mavlink packets over UDP to hub but for some reason was unable to with the default docker-compose settings. Now the docker containers run in host mode to resolve this issue. More
info here: https://app.clickup.com/t/2cdb9yd