### PR TITLE
Minor CSS doodad on Control Page

### DIFF
--- a/houston/src/index.css
+++ b/houston/src/index.css
@@ -25,11 +25,13 @@ code {
 	--dark-bg: #00204a;
   --med-bg: #2667ff;
   --light-bg: #3f8efc;
+  --grey-out-bg: #808080;
 
 	--highlight: #fdb44b; 
 
   --dark-text: #111111; 
   --light-text: #DDDDDD;
+
 
   --success-text: #33AA66; 
   --failure-text: #AA3344;

--- a/houston/src/pages/Control.css
+++ b/houston/src/pages/Control.css
@@ -12,7 +12,7 @@
     box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.75) inset;
 }
 
-.map {
+.controls-page .map {
     flex: 70%;
     width: 100%;
     height: 100%;
@@ -21,7 +21,7 @@
     margin: 50px;
 }
 
-.flight-telemetry-container {
+.controls-page .flight-telemetry-container {
     display: flex;
     flex-direction: column;
     flex: 15%;
@@ -33,7 +33,7 @@
     box-shadow: 0px 0px 25px 0px rgba(0,0,0,0.75);
 }
 
-.flight-telemetry {
+.controls-page .flight-telemetry {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -46,7 +46,7 @@
     overflow: hidden;
 }
 
-.data {
+.controls-page .data {
     flex: 2;
     font-family: 'Courier New';
     font-size: 45px;
@@ -55,14 +55,14 @@
     margin: auto;
 }
 
-.heading {
+.controls-page .heading {
     flex: 1;
     font-size: 1.2dvw;
     margin: auto;
     margin-top: 1.5dvh;
 }
 
-.unit-indicator {
+.controls-page .unit-indicator {
     display: flex;
     align-self: center;
     align-items: center;
@@ -72,7 +72,7 @@
     margin-bottom: 1dvw;
 }
 
-.unit {
+.controls-page .unit {
     overflow: hidden;
     display: flex;
     flex: 1;
@@ -82,13 +82,32 @@
     font-weight: bold;
     padding: 0.5dvw;
     height: 1dvh;
-    background-color: var(--highlight);
     border-top-left-radius: 3dvh;
     border-bottom-left-radius: 3dvh;
-     user-select: none
+    user-select: none;
+    cursor: pointer;
+
+
+    transition: all var(--std-transition);
 }
 
-.unit:last-child {
+.controls-page .unit:first-child {
+    background: linear-gradient(to left, var(--highlight) 50%, var(--grey-out-bg) 50%) right;
+    background-size: 200% 100%;
+}
+
+.controls-page .unit.unit-selected:first-child {
+    background-position: right;
+}
+
+.controls-page .unit.unit-not-selected:first-child {
+    background-position: left;
+}
+
+.controls-page .unit:last-child {
+    background: linear-gradient(to left, var(--grey-out-bg) 50%, var(--highlight) 50%) right;
+    background-size: 200% 100%;
+
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     border-top-right-radius: 3dvh;
@@ -96,7 +115,15 @@
     border-left: 2px solid black;
 }
 
-#compass {
+.controls-page .unit.unit-selected:last-child {
+    background-position: left;
+}
+
+.controls-page .unit.unit-not-selected:last-child {
+    background-position: right;
+}
+
+.controls-page #compass {
     background-color: var(--highlight);
 }
 
@@ -108,30 +135,30 @@
         padding-right: 50px;
     }
 
-    .flight-telemetry-container {
+    .controls-page .flight-telemetry-container {
         flex-direction: row;
         padding-left: 0px;
         margin: 0px;
         width: 100%;
     }
 
-    .flight-telemetry {
+    .controls-page .flight-telemetry {
         margin-left: 20px;
         height: auto;
     }
 
-    .map {
+    .controls-page .map {
         margin: 20px;
     }
 
-    .heading {
+    .controls-page .heading {
         flex: 1;
         font-size: 2dvw;
         margin: auto;
         margin-top: 1.5dvh;
     }
 
-    .data {
+    .controls-page .data {
         flex: 2;
         font-family: 'Courier New';
         font-size: 45px;

--- a/houston/src/pages/Control.tsx
+++ b/houston/src/pages/Control.tsx
@@ -116,23 +116,21 @@ interface TelemetryProps {
  * @returns the telemetry component
  */
 function TelemetryGenerator({ key, heading, color, value, units, unit, onClick }: TelemetryProps) {
-    let unit0_color = { backgroundColor: '#808080' };
-    let unit1_color = { backgroundColor: 'var(--secondary-text)' };
     if (units[0] !== units[1]) {
-        if (unit === units[0]) {
-            unit0_color = { backgroundColor: 'var(--highlight)' };
-            unit1_color = { backgroundColor: '#808080' };
-        } else {
-            unit0_color = { backgroundColor: '#808080' };
-            unit1_color = { backgroundColor: 'var(--highlight)' };
+        let unit0_class = 'unit-selected';
+        let unit1_class = 'unit-not-selected';
+
+        if (unit !== units[0]) {
+            [unit0_class, unit1_class] = [unit1_class, unit0_class]; // swap
         }
+
         return (
             <div key={key} style={color} className='flight-telemetry' onClick={onClick}>
                 <h1 className='heading'>{heading}</h1>
                 <p className='data'>{value} {unit}</p>
                 <div className='unit-indicator'>
-                    <p className='unit' style={unit0_color}>{units[0]}</p>
-                    <p className='unit' style={unit1_color}>{units[1]}</p>
+                    <p className={`unit ${unit0_class}`} >{units[0]}</p>
+                    <p className={`unit ${unit1_class}`} >{units[1]}</p>
                 </div>
             </div>
         );


### PR DESCRIPTION
I thought of this in a dream.

1. Try clicking on the unit change slider :smile: 
2. I scoped all of the css rules in the Controls.css file b/c I realized that I didn't notice they weren't before. (I've just been prefixing every css rule with the class name of the main containing element for that page. I think if you want to actually scope css files to specific react components, then you probably have to set up something else. Right now there are no collisions between class names, but in the future other pages might make elements with the same class names, so we don't want those to collide since both css stylesheets will be active at the same time).