### PR TITLE
Feat/135 targetrename

### DIFF
--- a/houston/src/pages/Input.tsx
+++ b/houston/src/pages/Input.tsx
@@ -719,3 +719,5 @@ function Input() {
 
 export default Input;
 
+
+


### PR DESCRIPTION
closes #135
I removed the color, shape, alphanumeric properties and all references to it from Input.tsx and Report.tsx and added a property Object & respective functions that lists all the objects that are targets this year like mattress, airplane etc. The Objects list is in the protos branch, related to issue 142. 