### PR TITLE
Update Fetching Behavior

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.8.0
 
   eslint:
     name: Lint Frontend

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install-linter:
 	fi;\
 
 install-protos:
-	sudo apt install protobuf-compiler
+	sudo apt-get update && sudo apt-get install -y protobuf-compiler
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 	echo "You will need to set your PATH variable to include go installations, if you have not already done so."
 

--- a/houston/src/App.tsx
+++ b/houston/src/App.tsx
@@ -46,59 +46,94 @@ function App() {
   const [coordinate, setCoordinate] = useState<LatLng[]>([]);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      fetch("/api/plane/telemetry?id=33&field=lat,lon,alt,relative_alt")
+    let isCancelled = false;
+    let planeTimeoutId: number | null = null;
+    let statusTimeoutId: number | null = null;
+
+    const pollPlaneTelemetry = async () => {
+      await fetch("/api/plane/telemetry?id=33&field=lat,lon,alt,relative_alt")
         .then((resp) => resp.json())
         .then((json) => {
           const lat = parseFloat(json["lat"]) / 10e6;
           const lng = parseFloat(json["lon"]) / 10e6;
-          setPlaneLatLng([lat, lng]);
+          if (!isCancelled) {
+            setPlaneLatLng([lat, lng]);
+          }
+        })
+        .catch((error) => {
+          console.error("Error fetching plane telemetry:", error);
         });
-    }, 500);
 
-    const interval_long = setInterval(() => {
-      // I hate this but don't feel motivated to refactor it, sorry ~Tyler 4/13/24
-      fetch("/api/connections")
-        .then((resp) => resp.json())
-        .then((json) => {
-          setStatuses((old) =>
-            old.map((status: ConnectionStatus) => {
-              switch (status.name) {
-                case "Antenna Tracker":
-                  return {
-                    isActive: json["antenna_tracker"],
-                    type: status.type,
-                    name: status.name,
-                  } as ConnectionStatus;
-                case "Onboard Computer":
-                  return {
-                    isActive: json["plane_obc"],
-                    type: status.type,
-                    name: status.name,
-                  } as ConnectionStatus;
-                case "Radio Mavlink":
-                  return {
-                    isActive: json["radio_mavlink"],
-                    type: status.type,
-                    name: status.name,
-                  } as ConnectionStatus;
-                default:
-                  return {} as ConnectionStatus;
-              }
-            }),
-          );
-        });
-      fetch("/api/obc_connection")
-        .then((resp) => resp.json())
-        .then((json) => {
-          // these keys are defined in the /connections route of the backend
-          localStorage.setItem("obc_conn_status", JSON.stringify(json));
-        });
-    }, 2000);
+      if (!isCancelled) {
+        planeTimeoutId = window.setTimeout(() => {
+          void pollPlaneTelemetry();
+        }, 500);
+      }
+    };
+
+    const pollConnectionStatus = async () => {
+      await Promise.allSettled([
+        fetch("/api/connections")
+          .then((resp) => resp.json())
+          .then((json) => {
+            if (isCancelled) {
+              return;
+            }
+            setStatuses((old) =>
+              old.map((status: ConnectionStatus) => {
+                switch (status.name) {
+                  case "Antenna Tracker":
+                    return {
+                      isActive: json["antenna_tracker"],
+                      type: status.type,
+                      name: status.name,
+                    } as ConnectionStatus;
+                  case "Onboard Computer":
+                    return {
+                      isActive: json["plane_obc"],
+                      type: status.type,
+                      name: status.name,
+                    } as ConnectionStatus;
+                  case "Radio Mavlink":
+                    return {
+                      isActive: json["radio_mavlink"],
+                      type: status.type,
+                      name: status.name,
+                    } as ConnectionStatus;
+                  default:
+                    return {} as ConnectionStatus;
+                }
+              }),
+            );
+          }),
+        fetch("/api/obc_connection")
+          .then((resp) => resp.json())
+          .then((json) => {
+            if (!isCancelled) {
+              // these keys are defined in the /connections route of the backend
+              localStorage.setItem("obc_conn_status", JSON.stringify(json));
+            }
+          }),
+      ]);
+
+      if (!isCancelled) {
+        statusTimeoutId = window.setTimeout(() => {
+          void pollConnectionStatus();
+        }, 2000);
+      }
+    };
+
+    void pollPlaneTelemetry();
+    void pollConnectionStatus();
 
     return () => {
-      clearInterval(interval);
-      clearInterval(interval_long);
+      isCancelled = true;
+      if (planeTimeoutId !== null) {
+        window.clearTimeout(planeTimeoutId);
+      }
+      if (statusTimeoutId !== null) {
+        window.clearTimeout(statusTimeoutId);
+      }
     };
   }, []);
 

--- a/houston/src/pages/Control.tsx
+++ b/houston/src/pages/Control.tsx
@@ -320,55 +320,89 @@ function Control({
 
   const [tickState, setTickState] = useState<string>("Loading...");
 
-  // --- NEW useEffect specifically for fetching tick state ---
+  // useEffect for fetching tick state
   useEffect(() => {
-    const fetchTickState = () => {
-      fetch("/api/tickstate")
-        .then((response) => {
-          if (!response.ok) {
+    let isCancelled = false;
+    let tickTimeoutId: number | null = null;
+    let tickRequestInFlight = false;
+
+    const pollTickState = async () => {
+      if (tickRequestInFlight || isCancelled) {
+        return;
+      }
+
+      tickRequestInFlight = true;
+      try {
+        const response = await fetch("/api/tickstate");
+        if (!response.ok) {
+          if (!isCancelled) {
             setTickState(`Error: ${response.status}`);
-            throw new Error(`Tickstate fetch failed: ${response.status}`);
           }
-          return response.text();
-        })
-        .then((data) => {
+          throw new Error(`Tickstate fetch failed: ${response.status}`);
+        }
+
+        const data = await response.text();
+        if (!isCancelled) {
           setTickState(data);
-        })
-        .catch((error) => {
-          console.error("Error fetching tick state:", error);
+        }
+      } catch (error) {
+        console.error("Error fetching tick state:", error);
+        if (!isCancelled) {
           setTickState("Error");
-        });
+        }
+      } finally {
+        tickRequestInFlight = false;
+        if (!isCancelled) {
+          tickTimeoutId = window.setTimeout(() => {
+            void pollTickState();
+          }, 3000);
+        }
+      }
     };
 
-    fetchTickState(); // Fetch immediately on component mount
-    const tickInterval = setInterval(fetchTickState, 1000); // Then fetch every second
+    void pollTickState();
 
     return () => {
-      clearInterval(tickInterval); // Cleanup interval on component unmount
+      isCancelled = true;
+      if (tickTimeoutId !== null) {
+        window.clearTimeout(tickTimeoutId);
+      }
     };
-  }, []); // Empty dependency array ensures this runs once on mount and cleans up on unmount
+  }, []);
 
   useEffect(() => {
-    const interval = setInterval(
-      () =>
-        pullTelemetry(
-          settings,
-          setPlaneLatLng,
-          setAirspeed,
-          setGroundspeed,
-          setAltitudeMSL,
-          setAltitudeAGL,
-          setMotorBattery,
-          setPixhawkBattery,
-          setESCtemperature,
-          setSuperSecret,
-          setFlightMode,
-        ),
-      1000,
-    );
+    let isCancelled = false;
+    let telemetryTimeoutId: number | null = null;
+
+    const pollTelemetry = async () => {
+      await pullTelemetry(
+        settings,
+        setPlaneLatLng,
+        setAirspeed,
+        setGroundspeed,
+        setAltitudeMSL,
+        setAltitudeAGL,
+        setMotorBattery,
+        setPixhawkBattery,
+        setESCtemperature,
+        setSuperSecret,
+        setFlightMode,
+      );
+
+      if (!isCancelled) {
+        telemetryTimeoutId = window.setTimeout(() => {
+          void pollTelemetry();
+        }, 1000);
+      }
+    };
+
+    void pollTelemetry();
 
     return () => {
-      clearInterval(interval);
+      isCancelled = true;
+      if (telemetryTimeoutId !== null) {
+        window.clearTimeout(telemetryTimeoutId);
+      }
     };
   }, [settings]);
 

--- a/houston/src/pages/Report.tsx
+++ b/houston/src/pages/Report.tsx
@@ -200,7 +200,7 @@ const Reports: React.FC = () => {
   const [manualInputError, setManualInputError] = useState<string>("");
 
   // Refs
-  const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
+  const pollingTimeoutRef = useRef<number | null>(null);
   const isMountedRef = useRef<boolean>(true);
   const imageContainerRef = useRef<HTMLDivElement>(null);
   const isFetchingTargetsRef = useRef<boolean>(false);
@@ -321,30 +321,34 @@ const Reports: React.FC = () => {
       return;
     }
 
-    const performInitialLiveFetch = async () => {
-      if (isMountedRef.current) setIsPollingUI(true);
-      await fetchAndProcessLatest(true);
-      if (isMountedRef.current) setIsPollingUI(false);
-    };
+    let isCancelled = false;
+    let localTimeoutId: number | null = null;
 
-    performInitialLiveFetch();
-
-    const localIntervalId = setInterval(async () => {
-      if (!isMountedRef.current) {
-        clearInterval(localIntervalId);
+    const pollLatestRuns = async (isInitialFetch: boolean) => {
+      if (!isMountedRef.current || isCancelled) {
         return;
       }
-      if (isMountedRef.current) setIsPollingUI(true);
-      await fetchAndProcessLatest(false);
-      if (isMountedRef.current) setIsPollingUI(false);
-    }, POLLING_INTERVAL_MS);
-    intervalIdRef.current = localIntervalId;
+
+      setIsPollingUI(true);
+      await fetchAndProcessLatest(isInitialFetch);
+
+      if (isMountedRef.current && !isCancelled) {
+        setIsPollingUI(false);
+        localTimeoutId = window.setTimeout(() => {
+          void pollLatestRuns(false);
+        }, POLLING_INTERVAL_MS);
+        pollingTimeoutRef.current = localTimeoutId;
+      }
+    };
+
+    void pollLatestRuns(true);
 
     return () => {
-      if (localIntervalId) {
-        clearInterval(localIntervalId);
+      isCancelled = true;
+      if (localTimeoutId !== null) {
+        window.clearTimeout(localTimeoutId);
       }
-      intervalIdRef.current = null;
+      pollingTimeoutRef.current = null;
     };
   }, [hasLoadedInitialSavedRuns, fetchAndProcessLatest]);
 
@@ -380,8 +384,8 @@ const Reports: React.FC = () => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
-      if (intervalIdRef.current) {
-        clearInterval(intervalIdRef.current);
+      if (pollingTimeoutRef.current !== null) {
+        window.clearTimeout(pollingTimeoutRef.current);
       }
     };
   }, []);

--- a/houston/src/utilities/pull_telemetry.ts
+++ b/houston/src/utilities/pull_telemetry.ts
@@ -23,7 +23,7 @@ import { SettingsConfig } from "./settings";
  * @param setSuperSecret state setter
  * @param setFlightMode state setter
  */
-export function pullTelemetry(
+export async function pullTelemetry(
   settings: SettingsConfig,
   setPlaneLatLng: Dispatch<SetStateAction<[number, number]>>,
   setAirspeedVal: Dispatch<SetStateAction<Parameter>>,
@@ -36,7 +36,7 @@ export function pullTelemetry(
   setSuperSecret: Dispatch<SetStateAction<boolean>>,
   setFlightMode: Dispatch<SetStateAction<string>>,
 ) {
-  fetch("/api/plane/telemetry?id=74&field=groundspeed,airspeed,heading")
+  const speedRequest = fetch("/api/plane/telemetry?id=74&field=groundspeed,airspeed,heading")
     .then((resp) => resp.json())
     .then((json) => {
       const airspeed = json["airspeed"];
@@ -50,7 +50,8 @@ export function pullTelemetry(
       setGroundspeedVal((param) => param.getErrorValue());
       setSuperSecret(true);
     });
-  fetch("/api/plane/telemetry?id=33&field=lat,lon,alt,relative_alt")
+
+  const positionRequest = fetch("/api/plane/telemetry?id=33&field=lat,lon,alt,relative_alt")
     .then((resp) => resp.json())
     .then((json) => {
       const altitude = METERS_TO_FEET(MM_TO_METERS(json["alt"]));
@@ -66,7 +67,8 @@ export function pullTelemetry(
       setAltitudeAGLVal((param) => param.getErrorValue());
       // todo figure out good error value for latlng so the map doesn't flicker to africa
     });
-  fetch("/api/plane/telemetry?id=251&field=value")
+
+  const escRequest = fetch("/api/plane/telemetry?id=251&field=value")
     .then((resp) => resp.json())
     .then((json) => {
       const esc_temp = json["value"];
@@ -75,7 +77,8 @@ export function pullTelemetry(
     .catch((_) => {
       setESCtemperatureVal((param) => param.getErrorValue());
     });
-  fetch("/api/plane/telemetry?id=0")
+
+  const flightModeRequest = fetch("/api/plane/telemetry?id=0")
     .then((resp) => resp.json())
     .then((json) => {
       // some respectable individual can come in later on and refactor this into
@@ -116,7 +119,7 @@ export function pullTelemetry(
         }
       }
     });
-  fetch("/api/plane/voltage")
+  const voltageRequest = fetch("/api/plane/voltage")
     .then((resp) => resp.json())
     .then((json) => {
       const pixhawkV = json["0"] / 1000; //kV -> V
@@ -135,4 +138,12 @@ export function pullTelemetry(
       setPixhawkBatteryVal((param) => param.getErrorValue());
       setMotorBatteryVal((param) => param.getErrorValue());
     });
+
+  await Promise.allSettled([
+    speedRequest,
+    positionRequest,
+    escRequest,
+    flightModeRequest,
+    voltageRequest,
+  ]);
 }


### PR DESCRIPTION
Closes #199 

# Main Changes
- Changed `setInteval` to `setTimeout` for both tick state and mav
- Updated the rate of tick state polling to 3 seconds, and it only runs AFTER we receive the previous response
- CI was failing because of inconsistent versions of go lint (and outdated apt for whatever reason), I fixed it by setting a specific golangci version (2.8.0) in the CI and slapping on an apt update in the Makefile.
 
# To Test
On OBC, in `gcs_routes.cpp`, include chrono and threads at the top, then add the following to line ~523. This adds an artificial delay for the response.
```
std::this_thread::sleep_for(std::chrono::seconds(10));
```
Then recompile and run sitl.

## Expected Behavior
On the reports page, open the networks tab (devtools). There should not be any `(pending)` stacking up.