### PR TITLE
changed tickstate description to "loading..." when it's html

### DIFF
--- a/houston/src/pages/Control.tsx
+++ b/houston/src/pages/Control.tsx
@@ -345,6 +345,9 @@ function Control({
         if (!isCancelled) {
           setTickState(data);
         }
+        if (data[0] == "<") {
+          setTickState("Loading...");
+        }
       } catch (error) {
         console.error("Error fetching tick state:", error);
         if (!isCancelled) {

--- a/houston/src/pages/Control.tsx
+++ b/houston/src/pages/Control.tsx
@@ -345,7 +345,8 @@ function Control({
         if (!isCancelled) {
           setTickState(data);
         }
-        if (data[0] == "<") {
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.includes("text/html")) {
           setTickState("Loading...");
         }
       } catch (error) {


### PR DESCRIPTION
When running gcs localy the control page tickstate returns HTML
Changed it to "loading..." when that happens